### PR TITLE
Nemo 5206 - use the correct amount in cancel api request

### DIFF
--- a/lib/ccavenue-sdk.rb
+++ b/lib/ccavenue-sdk.rb
@@ -154,7 +154,8 @@ module CcavenueApi
 
     def refund!(transaction)
       response = build_and_invoke_api_request(transaction) do
-        data = {'order_List' => [{reference_no: transaction.tracking_id, amount: transaction.ccavenue_amount.to_s}]}.to_json
+        data = {reference_no: transaction.tracking_id, refund_amount: transaction.ccavenue_amount.to_s,
+                refund_ref_no: transaction.ccavenue_order_number}.to_json
         req_builder.refund_order(data)
       end
       Rails.logger.info %Q!Refund api request returned #{response.refund_successful? ? 'successfully' : "with a failure '#{response.reason}'"}!

--- a/lib/ccavenue-sdk.rb
+++ b/lib/ccavenue-sdk.rb
@@ -145,7 +145,7 @@ module CcavenueApi
 
     def cancel!(transaction)
       response = build_and_invoke_api_request(transaction) do
-        data = {'order_List' => [{reference_no: transaction.tracking_id, amount: transaction.amount.to_s}]}.to_json
+        data = {'order_List' => [{reference_no: transaction.tracking_id, amount: transaction.ccavenue_amount.to_s}]}.to_json
         req_builder.cancel_order(data)
       end
       Rails.logger.info %Q!Cancel api request returned #{response.cancel_successful? ? 'successfully' : "with a failure '#{response.reason}'"}!

--- a/lib/ccavenue-sdk.rb
+++ b/lib/ccavenue-sdk.rb
@@ -154,7 +154,7 @@ module CcavenueApi
 
     def refund!(transaction)
       response = build_and_invoke_api_request(transaction) do
-        data = {'order_List' => [{reference_no: transaction.tracking_id, amount: transaction.amount.to_s}]}.to_json
+        data = {'order_List' => [{reference_no: transaction.tracking_id, amount: transaction.ccavenue_amount.to_s}]}.to_json
         req_builder.refund_order(data)
       end
       Rails.logger.info %Q!Refund api request returned #{response.refund_successful? ? 'successfully' : "with a failure '#{response.reason}'"}!

--- a/spec/lib/CcavenueApi/sdk_spec.rb
+++ b/spec/lib/CcavenueApi/sdk_spec.rb
@@ -17,6 +17,7 @@ describe CcavenueApi::SDK do
   let(:order) { FactoryGirl.create(:order_with_totals) }
   let(:cc_transaction) { double('ccavenue_transaction', :id => 123, :tracking_id => '1234', :amount => 123, :ccavenue_amount => 456) }
   let(:data_for_cancel) { { 'order_List' => [{ reference_no: cc_transaction.tracking_id, amount: cc_transaction.ccavenue_amount.to_s }] }.to_json }
+  let(:data_for_refund) { { 'order_List' => [{ reference_no: cc_transaction.tracking_id, amount: cc_transaction.ccavenue_amount.to_s }] }.to_json }
   let(:req_builder) { double('req builder') }
   let(:crypter) { double('crypter') }
 
@@ -149,13 +150,12 @@ describe CcavenueApi::SDK do
 
   describe "#cancel!" do
     let(:cancel_res) { CcavenueApi::Response.new(http_status: :success, api_status: :success, success_count: 1) }
+    before(:each) { allow(sdk).to receive(:req_builder).and_return(req_builder) }
     it "invokes build_and_invoke_api_request and returns the response from it" do
-      allow(sdk).to receive(:req_builder).and_return(req_builder)
       expect(sdk).to receive(:build_and_invoke_api_request).and_return(cancel_res)
       expect(sdk.cancel!(cc_transaction)).to eq(cancel_res)
     end
     it "invokes req_builder cancel_order" do
-      allow(sdk).to receive(:req_builder).and_return(req_builder)
       allow(sdk).to receive(:api_request).and_return(cancel_res)
       expect(req_builder).to receive(:cancel_order).with(data_for_cancel)
       expect(sdk.cancel!(cc_transaction)).to eq(cancel_res)
@@ -164,13 +164,14 @@ describe CcavenueApi::SDK do
 
   describe "#refund!" do
     let(:refund_res) { CcavenueApi::Response.new(http_status: :success, api_status: :success, refund_status: 0) }
+    before(:each) { allow(sdk).to receive(:req_builder).and_return(req_builder) }
     it "invokes build_and_invoke_api_request and returns the response from it" do
       expect(sdk).to receive(:build_and_invoke_api_request).and_return(refund_res)
       expect(sdk.refund!(cc_transaction)).to eq(refund_res)
     end
     it "invokes req_builder refund order" do
       allow(sdk).to receive(:api_request).and_return(refund_res)
-      expect(sdk).to receive(:req_builder).and_return(req_builder=double('req builder', refund_order: '123'))
+      expect(req_builder).to receive(:refund_order).with(data_for_refund)
       expect(sdk.refund!(cc_transaction)).to eq(refund_res)
     end
   end

--- a/spec/lib/CcavenueApi/sdk_spec.rb
+++ b/spec/lib/CcavenueApi/sdk_spec.rb
@@ -15,9 +15,11 @@ describe CcavenueApi::SDK do
   let(:test_sdk) { CcavenueApi::SDK.new(sdk_args.merge(:test_mode => true)) }
   let(:prod_sdk) { CcavenueApi::SDK.new(sdk_args.merge(:test_mode => false)) }
   let(:order) { FactoryGirl.create(:order_with_totals) }
-  let(:cc_transaction) { double('ccavenue_transaction', :id => 123, :tracking_id => '1234', :amount => 123, :ccavenue_amount => 456) }
+  let(:cc_transaction) { double('ccavenue_transaction', :id => 123, :tracking_id => '1234', :amount => 123, :ccavenue_amount => 456,
+                                ccavenue_order_number: 'R1234') }
   let(:data_for_cancel) { { 'order_List' => [{ reference_no: cc_transaction.tracking_id, amount: cc_transaction.ccavenue_amount.to_s }] }.to_json }
-  let(:data_for_refund) { { 'order_List' => [{ reference_no: cc_transaction.tracking_id, amount: cc_transaction.ccavenue_amount.to_s }] }.to_json }
+  let(:data_for_refund) { { reference_no: cc_transaction.tracking_id, refund_amount: cc_transaction.ccavenue_amount.to_s,
+    refund_ref_no: cc_transaction.ccavenue_order_number }.to_json }
   let(:req_builder) { double('req builder') }
   let(:crypter) { double('crypter') }
 


### PR DESCRIPTION
While creating the cancel request for a transaction, the code was using the amount which was based on order total. However if the actual amount charged by ccavnue is different, the cancel api request fails since amounts mismatch. So now the code is using the actual amount charged by ccavenue in a subsequent cancel api request. 
