### PR TITLE
logging cleanup

### DIFF
--- a/app/controllers/spree/ccavenue_controller.rb
+++ b/app/controllers/spree/ccavenue_controller.rb
@@ -18,7 +18,6 @@ module Spree
 
     # return from ccavenue
     def callback
-      Rails.logger.debug "Received callback from CCAvenue #{params.inspect}"
       @cc_params = provider.parse_redirect_response(params['encResp'])
       transaction = ccavenue_transaction || raise(ActiveRecord::RecordNotFound)
       provider.update_transaction_from_redirect_response(transaction, @cc_params)

--- a/app/models/spree/gateway/ccavenue.rb
+++ b/app/models/spree/gateway/ccavenue.rb
@@ -55,13 +55,11 @@ module Spree
         ActiveMerchant::Billing::Response.new(false, Spree.t('ccavenue.generic_failed'), { :message => transaction.transaction_error },
                                               :test => self.preferred_test_mode)
       end
-      Rails.logger.debug "Returning from ccavenue#purchase: #{ret.inspect}"
       ret
     end
 
     # payment profiles are supported
     def void(tracking_id, options={})
-      Rails.logger.debug "tracking id #{tracking_id}"
       response = provider.void!(tracking_id)
       ret = if response.void_successful?
         ActiveMerchant::Billing::Response.new(true, Spree.t('ccavenue.void_successful'), {},
@@ -70,7 +68,6 @@ module Spree
         ActiveMerchant::Billing::Response.new(false, Spree.t('ccavenue.void_failed'), { :message => response.reason },
                                               :test => self.preferred_test_mode)
       end
-      Rails.logger.debug "Returning from ccavenue#void: #{ret.inspect}"
       ret
     end
 

--- a/lib/api_caller.rb
+++ b/lib/api_caller.rb
@@ -57,7 +57,6 @@ module CcavenueApi
     def self.decrypted_response(url, params, encryption_key, verify_ssl=nil)
       response = nil
       begin
-        Rails.logger.info "Params sent to #{url}: #{params.inspect}\nverify_ssl: '#{verify_ssl}'"
         response = RestClient::Request.execute(method: :post, url: url, payload: params,
                                 headers: {'Accept' => 'application/json', :accept_encoding => 'gzip, deflate'},
                                 verify_ssl: verify_ssl)
@@ -76,7 +75,6 @@ module CcavenueApi
     end
 
     def self.decrypt_response(response, encryption_key)
-      Rails.logger.info "Response from API: #{response.body.inspect}"
       params_s = response.body.to_s
       params = Rack::Utils.parse_query(params_s)
       ApiResponse.new(params, encryption_key)
@@ -124,7 +122,6 @@ module CcavenueApi
       def initialize_from_decrypted_response(encryption_key, params)
         enc_response = params['enc_response'].gsub('\r\n', '').strip
         json_params = ActiveSupport::JSON.decode(AESCrypter.decrypt(enc_response, encryption_key))
-        Rails.logger.info "Decrypted json params: #{json_params}"
         if json_params['Refund_Order_Result']
           self.refund_status = json_params['Refund_Order_Result']['refund_status']
           self.reason = json_params['Refund_Order_Result']['reason'] # Only present for failed requests

--- a/lib/ccavenue-sdk.rb
+++ b/lib/ccavenue-sdk.rb
@@ -183,9 +183,7 @@ module CcavenueApi
 
     def build_and_invoke_api_request(transaction)
       raise ArgumentError.new(Spree.t('ccavenue.unable_to_void')) unless transaction.tracking_id
-      response = api_request(yield)
-      Rails.logger.debug "Received following API response: #{response.inspect} for ccave transaction #{transaction.id}"
-      response
+      api_request(yield)
     end
 
 

--- a/lib/ccavenue-sdk.rb
+++ b/lib/ccavenue-sdk.rb
@@ -3,10 +3,7 @@ require 'rest-client'
 require 'aes_crypter'
 
 module CcavenueApi
-  ################################
   class Crypter
-    ################################
-
     def initialize(encryption_key)
       @encryption_key = encryption_key
     end
@@ -20,9 +17,7 @@ module CcavenueApi
     end
   end
 
-  ################################
   class SDK
-    ################################
     URLS = {
       transaction: {
         production: "https://secure.ccavenue.com/transaction/transaction.do?command=initiateTransaction",
@@ -48,8 +43,6 @@ module CcavenueApi
       end
     end
 
-    #################################### instance
-
     attr_reader :transaction_url, :api_url, :signup_url,
                 :merchant_id, :access_code, :encryption_key, :test_mode
 
@@ -70,9 +63,7 @@ module CcavenueApi
       Spree::Ccavenue::Transaction
     end
 
-    ###############
     # Browser Redirect methods
-    #
     def build_ccavenue_checkout_transaction(order)
       ccavenue_transaction_class.create!(:amount                => order.total.to_s,
                                          :currency              => order.currency.to_s,
@@ -91,9 +82,7 @@ module CcavenueApi
                                           merchant_param4: nil,
                                           merchant_param5: nil
                                         })
-      req            = crypter.encrypt(request_params.to_query)
-      Rails.logger.debug "Encrypting params: #{request_params.inspect} to #{req}"
-      req
+      crypter.encrypt(request_params.to_query)
     end
 
     def parse_redirect_response(encrypted_response)
@@ -101,7 +90,6 @@ module CcavenueApi
     end
 
     def update_transaction_from_redirect_response(transaction, cc_params)
-      Rails.logger.info "Decrypted params from ccavenue #{cc_params.inspect}"
       transaction.update_attributes!(
         :auth_desc       => cc_params['order_status'],
         :card_category   => cc_params['card_name'],
@@ -121,7 +109,6 @@ module CcavenueApi
       init_from_merchant_credentials(new_access_code, new_encryption_key)
       data     = {reference_no: '', order_no: ''}.to_json # empty order id
       response = api_request(req_builder.order_status(data))
-      Rails.logger.info "Received following API validation response: #{response.inspect}"
       response.credentials_valid?
     ensure
       # restore old creds back
@@ -176,7 +163,6 @@ module CcavenueApi
       @req_builder
     end
 
-    #####################################
     private
 
     def init_from_merchant_credentials(new_access_code, new_encryption_key)
@@ -205,10 +191,7 @@ module CcavenueApi
 
   end
 
-  ################################
-  ################################
   class RequestBuilder
-
     attr_reader :crypter
 
     def initialize(access_code, crypter)
@@ -241,18 +224,13 @@ module CcavenueApi
     end
   end
 
-  ################################
-  ################################
   class Response
-
     class << self
       def failed_http_request(payload, decrypter)
         self.new(:reason => payload, :http_status => :failed, :original_payload => payload)
       end
 
       def successful_http_request(api_response, decrypter)
-        Rails.logger.debug "Received api response: #{api_response}"
-
         if api_response["status"] && api_response["status"] == "1"
           self.new(:reason           => api_response["enc_response"],
                    :http_status      => :success,
@@ -261,8 +239,6 @@ module CcavenueApi
           )
         else
           decrypted_payload = decrypter.decrypt(api_response['enc_response'].gsub('\r\n', '').strip)
-          Rails.logger.debug "Decrypted response: #{decrypted_payload}"
-
           decrypted_hash = ActiveSupport::JSON.decode(decrypted_payload)
           parsed         = build_from_response(decrypted_hash)
           self.new({
@@ -317,7 +293,6 @@ module CcavenueApi
       end
     end
 
-    ################################
     attr_reader :http_status, :api_status, :original_payload
 
     def initialize(opts)


### PR DESCRIPTION
remove unfiltered logging of parameters and api request/response information, which may (likely) contain PII data and should not be written to application logs